### PR TITLE
Replace/Update NuGet Packages that no longer exist.

### DIFF
--- a/Audibly.App/App.xaml.cs
+++ b/Audibly.App/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿// Author: rstewa · https://github.com/rstewa
+// Author: rstewa · https://github.com/rstewa
 // Updated: 07/30/2025
 
 using System;

--- a/Audibly.App/Audibly.App.csproj
+++ b/Audibly.App/Audibly.App.csproj
@@ -107,7 +107,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoMapper" Version="14.0.0" />
-        <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.250206-build.2040" />
+        <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.251217-build.2433" />
         <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.Marquee" Version="0.1.251217-build.2433" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />

--- a/Audibly.App/Audibly.App.csproj
+++ b/Audibly.App/Audibly.App.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
         <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
@@ -26,7 +26,7 @@
     </PropertyGroup>
 
     <!-- We recommend only using these features for release builds. -->
-    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PropertyGroup Condition="'$(Configuration)' == 'Release' and '$(SENTRY_AUTH_TOKEN)' != ''">
         <!-- Configure Sentry org and project -->
         <SentryOrg>audibly</SentryOrg>
         <SentryProject>audibly</SentryProject>
@@ -106,9 +106,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="14.0.0"/>
+        <PackageReference Include="AutoMapper" Version="14.0.0" />
         <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock" Version="0.1.250206-build.2040" />
-        <PackageReference Include="CommunityToolkit.Labs.WinUI.MarqueeText" Version="0.1.250206-build.2040" />
+        <PackageReference Include="CommunityToolkit.Labs.WinUI.Controls.Marquee" Version="0.1.251217-build.2433" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.2.250402" />
         <PackageReference Include="CommunityToolkit.WinUI.Controls.TokenizingTextBox" Version="8.2.250402" />

--- a/Audibly.App/UserControls/TitleArtistStack.xaml
+++ b/Audibly.App/UserControls/TitleArtistStack.xaml
@@ -5,7 +5,7 @@
     x:Class="Audibly.App.UserControls.TitleArtistStack"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:labs="using:CommunityToolkit.Labs.WinUI.MarqueeTextRns"
+    xmlns:controls="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
@@ -17,14 +17,14 @@
         x:Name="TitleArtistStackPanel">
 
         <!--  Title  -->
-        <labs:MarqueeText
+        <controls:Marquee
             Behavior="Looping"
             Direction="Left"
             FontSize="{x:Bind TitleFontSize, Mode=OneWay}"
             FontWeight="SemiBold"
             MaxWidth="{x:Bind TitleMaxWidth, Mode=OneWay}"
             Speed="15"
-            Text="{x:Bind PlayerViewModel.NowPlaying.Title, Mode=OneWay}"
+            Content="{x:Bind PlayerViewModel.NowPlaying.Title, Mode=OneWay}"
             x:Name="TitleMarqueeText" />
 
         <!--  Artist  -->
@@ -51,21 +51,5 @@
             Visibility="{x:Bind ShowChapterTitle, Mode=OneWay}"
             x:Name="CurrentChapterTitleTextBlock" />
 
-        <!--  <labs:MarqueeText  -->
-        <!--  x:Name="CurrentChapterTitleMarqueeText"  -->
-        <!--  MaxWidth="{x:Bind TitleMaxWidth, Mode=OneWay}"  -->
-        <!--  Margin="0,4,0,0"  -->
-        <!--  VerticalAlignment="Bottom"  -->
-        <!--  Behavior="Looping"  -->
-        <!--  Direction="Left"  -->
-        <!--  FontSize="{x:Bind ArtistFontSize, Mode=OneWay}"  -->
-        <!--  FontStyle="Italic"  -->
-        <!--  Foreground="{ThemeResource TextFillColorTertiaryBrush}"  -->
-        <!--  PointerEntered="CurrentChapterTitleTextBlock_OnPointerEntered"  -->
-        <!--  PointerExited="CurrentChapterTitleMarqueeText_OnPointerExited"  -->
-        <!--  Speed="15"  -->
-        <!--  Text="{x:Bind PlayerViewModel.NowPlaying.CurrentChapterTitle, Mode=OneWay}"  -->
-        <!--  ToolTipService.ToolTip="{x:Bind PlayerViewModel.NowPlaying.CurrentChapterTitle, Mode=OneWay}"  -->
-        <!--  Visibility="{x:Bind ShowChapterTitle, Mode=OneWay}" />  -->
     </StackPanel>
 </UserControl>

--- a/Audibly.App/UserControls/TitleArtistStack.xaml
+++ b/Audibly.App/UserControls/TitleArtistStack.xaml
@@ -18,11 +18,13 @@
 
         <!--  Title  -->
         <controls:Marquee
+            AutoPlay="True"
             Behavior="Looping"
             Direction="Left"
             FontSize="{x:Bind TitleFontSize, Mode=OneWay}"
             FontWeight="SemiBold"
             MaxWidth="{x:Bind TitleMaxWidth, Mode=OneWay}"
+            RepeatBehavior="Forever"
             Speed="15"
             Content="{x:Bind PlayerViewModel.NowPlaying.Title, Mode=OneWay}"
             x:Name="TitleMarqueeText" />

--- a/Audibly.App/UserControls/TitleArtistStack.xaml.cs
+++ b/Audibly.App/UserControls/TitleArtistStack.xaml.cs
@@ -1,13 +1,9 @@
 // Author: rstewa · https://github.com/rstewa
 // Updated: 08/02/2025
 
-using System;
-using System.Threading.Tasks;
 using Audibly.App.ViewModels;
-using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Input;
 
 namespace Audibly.App.UserControls;
 
@@ -28,15 +24,9 @@ public sealed partial class TitleArtistStack : UserControl
     public static readonly DependencyProperty ShowChapterTitleProperty = DependencyProperty.Register(
         nameof(ShowChapterTitle), typeof(bool), typeof(TitleArtistStack), new PropertyMetadata(false));
 
-    private readonly DispatcherQueue _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
-
-    private bool _isPointerOver;
-
     public TitleArtistStack()
     {
         InitializeComponent();
-        TitleMarqueeText.MarqueeCompleted += TitleMarqueeText_MarqueeCompleted;
-        // CurrentChapterTitleMarqueeText.MarqueeCompleted += CurrentChapterTitleMarqueeText_MarqueeCompleted;
     }
 
     /// <summary>
@@ -74,27 +64,4 @@ public sealed partial class TitleArtistStack : UserControl
         set => SetValue(ShowChapterTitleProperty, value);
     }
 
-    private async void TitleMarqueeText_MarqueeCompleted(object? sender, EventArgs e)
-    {
-        _dispatcherQueue.TryEnqueue(() => TitleMarqueeText.StopMarquee());
-        await Task.Delay(TimeSpan.FromSeconds(5)); // wait for 3 seconds
-        _dispatcherQueue.TryEnqueue(() => TitleMarqueeText.StartMarquee());
-    }
-
-    // private void CurrentChapterTitleMarqueeText_MarqueeCompleted(object? sender, EventArgs e)
-    // {
-    //     if (!_isPointerOver) _dispatcherQueue.TryEnqueue(() => CurrentChapterTitleMarqueeText.StopMarquee());
-    // }
-    //
-    // private void CurrentChapterTitleTextBlock_OnPointerEntered(object sender, PointerRoutedEventArgs e)
-    // {
-    //     _dispatcherQueue.TryEnqueue(() => CurrentChapterTitleMarqueeText.StartMarquee());
-    //     _isPointerOver = true;
-    // }
-
-    private void CurrentChapterTitleMarqueeText_OnPointerExited(object sender, PointerRoutedEventArgs e)
-    {
-        _isPointerOver = false;
-        // _dispatcherQueue.TryEnqueue(() => CurrentChapterTitleMarqueeText.StopMarquee());
-    }
 }

--- a/Audibly.App/Views/ContentDialogs/ChangelogContentDialog.xaml
+++ b/Audibly.App/Views/ContentDialogs/ChangelogContentDialog.xaml
@@ -10,7 +10,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="using:Audibly.App.Views.ContentDialogs"
-    xmlns:markdownTextBlock="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdownTextBlock="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--  ReSharper disable all Xaml.RedundantResource  -->

--- a/Audibly.App/Views/ContentDialogs/ChangelogContentDialog.xaml.cs
+++ b/Audibly.App/Views/ContentDialogs/ChangelogContentDialog.xaml.cs
@@ -1,4 +1,4 @@
-using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Audibly.App.Views.ContentDialogs;

--- a/Audibly.App/Views/ControlPages/ChangelogDialogContent.xaml
+++ b/Audibly.App/Views/ControlPages/ChangelogDialogContent.xaml
@@ -7,7 +7,7 @@
     x:Class="Audibly.App.Views.ControlPages.ChangelogDialogContent"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:markdownTextBlock="using:CommunityToolkit.Labs.WinUI.MarkdownTextBlock"
+    xmlns:markdownTextBlock="using:CommunityToolkit.WinUI.Controls"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 

--- a/Audibly.App/Views/ControlPages/ChangelogDialogContent.xaml.cs
+++ b/Audibly.App/Views/ControlPages/ChangelogDialogContent.xaml.cs
@@ -3,7 +3,7 @@
 // Updated: 6/1/2024
 
 using Audibly.App.Helpers;
-using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Audibly.App.Views.ControlPages;

--- a/Audibly.App/Views/ControlPages/FailedDataMigrationContent.xaml.cs
+++ b/Audibly.App/Views/ControlPages/FailedDataMigrationContent.xaml.cs
@@ -1,5 +1,5 @@
 using Audibly.App.Helpers;
-using CommunityToolkit.Labs.WinUI.MarkdownTextBlock;
+using CommunityToolkit.WinUI.Controls;
 using Microsoft.UI.Xaml.Controls;
 
 namespace Audibly.App.Views.ControlPages;


### PR DESCRIPTION
The package for CommunityToolkit.Labs.WinUI.MarqueeText no longer exists, making it impossible to build this project since nuget restore fails, so this PR replaces it with CommunityToolkit.Labs.WinUI.Controls.Marquee and makes necessary changes to get the new package to work.

Additionally, this PR upgrades CommunityToolkit.Labs.WinUI.Controls.MarkdownTextBlock to the latest version, since the version originally referenced no longer exists.

Not sure if everything still works—I was mainly concerned with trying to get things to build with the new replacement package.