### PR TITLE
Set window title to 'Audibly' in MainWindow.xaml

### DIFF
--- a/Audibly.App/MainWindow.xaml
+++ b/Audibly.App/MainWindow.xaml
@@ -7,3 +7,4 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d" />
+    Title="Audibly" />


### PR DESCRIPTION
Updated MainWindow.xaml to explicitly set the window title. Currently, the application displays "WinUI Desktop" in the taskbar instead of the actual app name. Adding the Title attribute ensures that "Audibly" is correctly displayed when the app is running.

It's just a small change. But I noticed it, and it's been “sticking out” ever since.