### PR TITLE
add support for m4a and ogg file formats

### DIFF
--- a/Audibly.App/Package.appxmanifest
+++ b/Audibly.App/Package.appxmanifest
@@ -63,6 +63,24 @@
                         <uap:EditFlags OpenIsSafe="true"/>
                     </uap:FileTypeAssociation>
                 </uap:Extension>
+                <uap:Extension Category="windows.fileTypeAssociation">
+                    <uap:FileTypeAssociation Name="m4a">
+                        <uap:SupportedFileTypes>
+                            <uap:FileType>.m4a</uap:FileType>
+                        </uap:SupportedFileTypes>
+                        <uap:DisplayName>Audiobook Player</uap:DisplayName>
+                        <uap:EditFlags OpenIsSafe="true"/>
+                    </uap:FileTypeAssociation>
+                </uap:Extension>
+                <uap:Extension Category="windows.fileTypeAssociation">
+                    <uap:FileTypeAssociation Name="ogg">
+                        <uap:SupportedFileTypes>
+                            <uap:FileType>.ogg</uap:FileType>
+                        </uap:SupportedFileTypes>
+                        <uap:DisplayName>Audiobook Player</uap:DisplayName>
+                        <uap:EditFlags OpenIsSafe="true"/>
+                    </uap:FileTypeAssociation>
+                </uap:Extension>
             </Extensions>
         </Application>
     </Applications>

--- a/Audibly.App/Services/FileImportService.cs
+++ b/Audibly.App/Services/FileImportService.cs
@@ -43,7 +43,9 @@ public class FileImportService : IImportFiles
 
         var files = Directory.EnumerateFiles(path, "*.*", SearchOption.AllDirectories)
             .Where(file => file.EndsWith(".m4b", StringComparison.OrdinalIgnoreCase) ||
-                           file.EndsWith(".mp3", StringComparison.OrdinalIgnoreCase))
+                           file.EndsWith(".mp3", StringComparison.OrdinalIgnoreCase) ||
+                           file.EndsWith(".m4a", StringComparison.OrdinalIgnoreCase) ||
+                           file.EndsWith(".ogg", StringComparison.OrdinalIgnoreCase))
             .ToList();
         var numberOfFiles = files.Count;
 

--- a/Audibly.App/ViewModels/MainViewModel.cs
+++ b/Audibly.App/ViewModels/MainViewModel.cs
@@ -978,6 +978,8 @@ public class MainViewModel : BindableBase
         openPicker.ViewMode = PickerViewMode.Thumbnail;
         openPicker.FileTypeFilter.Add(".m4b");
         openPicker.FileTypeFilter.Add(".mp3");
+        openPicker.FileTypeFilter.Add(".m4a");
+        openPicker.FileTypeFilter.Add(".ogg");
 
         var file = await openPicker.PickSingleFileAsync();
         if (file == null) return;
@@ -1176,6 +1178,8 @@ public class MainViewModel : BindableBase
         openPicker.ViewMode = PickerViewMode.Thumbnail;
         openPicker.FileTypeFilter.Add(".m4b");
         openPicker.FileTypeFilter.Add(".mp3");
+        openPicker.FileTypeFilter.Add(".m4a");
+        openPicker.FileTypeFilter.Add(".ogg");
 
         var files = await openPicker.PickMultipleFilesAsync();
         if (files.IsNullOrEmpty()) return;

--- a/Audibly.App/Views/LibraryCardPage.xaml.cs
+++ b/Audibly.App/Views/LibraryCardPage.xaml.cs
@@ -39,13 +39,13 @@ public sealed partial class LibraryCardPage : Page
 
     #endregion
 
-    public const string ImportAudiobookText = "Import an audiobook (.m4b, mp3)";
+    public const string ImportAudiobookText = "Import an audiobook (.m4b, .mp3, .m4a, .ogg)";
 
     public const string ImportAudiobooksFromDirectoryText =
-        "Import all audiobooks in a directory (recursively). Single-file audiobooks only (.m4b, mp3)";
+        "Import all audiobooks in a directory (recursively). Single-file audiobooks only (.m4b, .mp3, .m4a, .ogg)";
 
     public const string ImportAudiobookWithMultipleFilesText =
-        "Import an audiobook made up of multiple files (.m4b, mp3)";
+        "Import an audiobook made up of multiple files (.m4b, .mp3, .m4a, .ogg)";
 
     public const string ImportFromJsonFileText = "Import audiobooks from an Audibly export file (.audibly)";
 


### PR DESCRIPTION
Added support in file type associations in `Package.appxmanifest` for .ogg and .m4b. Extended `FileImportService` to include `.m4a` and `.ogg` when scanning directories. Added `.m4a` and `.ogg` to the file pickers in `MainViewModel`. Updated UI text in `LibraryCardPage` to reflect the new supported formats.

Today, I wanted to play 'Reborn as the fated villain 2' but it's .ogg, that's why I'm trying to contribute to this project. While I was at it I found that there is an issue for .m4b so I added them both.